### PR TITLE
fix: code scanning alert no. 173: Log Injection

### DIFF
--- a/apps/backend/src/main/kotlin/com/lyra/app/users/application/UserRegistrator.kt
+++ b/apps/backend/src/main/kotlin/com/lyra/app/users/application/UserRegistrator.kt
@@ -24,7 +24,8 @@ class UserRegistrator(
     }
 
     suspend fun registerNewUser(registerUserCommand: RegisterUserCommand): ApiDataResponse<UserResponse> {
-        log.info("Registering new user with email: {}", registerUserCommand.email)
+        val sanitizedEmail = sanitizeInput(registerUserCommand.email)
+        log.info("Registering new user with email: {}", sanitizedEmail)
         return try {
             val user = registerUserCommand.toUser()
             val createdUser = userCreator.create(user)
@@ -61,5 +62,9 @@ class UserRegistrator(
 
     companion object {
         private val log = LoggerFactory.getLogger(UserRegistrator::class.java)
+
+        private fun sanitizeInput(input: String): String {
+            return input.replace("\n", "").replace("\r", "")
+        }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/dallay/lyra/security/code-scanning/173](https://github.com/dallay/lyra/security/code-scanning/173)

To fix the log injection issue, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the email address to prevent log injection attacks. This can be achieved by replacing newline characters with an empty string.

1. Modify the `registerNewUser` method in `UserRegistrator.kt` to sanitize the `registerUserCommand.email` before logging it.
2. Add a utility function to sanitize the input by removing newline characters.
3. Ensure that the logging statement uses the sanitized email.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
