### PR TITLE
fix: code scanning alert no. 167: Log Injection

### DIFF
--- a/apps/backend/src/main/kotlin/com/lyra/app/authentication/application/AuthenticateUserQueryHandler.kt
+++ b/apps/backend/src/main/kotlin/com/lyra/app/authentication/application/AuthenticateUserQueryHandler.kt
@@ -24,7 +24,8 @@ class AuthenticateUserQueryHandler(private val authenticator: UserAuthenticatorS
      * @return The response of the query.
      */
     override suspend fun handle(query: AuthenticateUserQuery): AccessToken {
-        log.info("Authenticating user with username: {}", query.username)
+        val sanitizedUsername = query.username.replace("\n", "").replace("\r", "")
+        log.info("Authenticating user with username: {}", sanitizedUsername)
         val username = Username(query.username)
         val password = Credential(CredentialId(UUID.randomUUID()), query.password)
         return authenticator.authenticate(username, password)


### PR DESCRIPTION
Fixes [https://github.com/dallay/lyra/security/code-scanning/167](https://github.com/dallay/lyra/security/code-scanning/167)

To fix the log injection issue, we need to sanitize the `query.username` before logging it. The best way to do this is to remove any potentially harmful characters, such as newlines, that could be used to forge log entries. We can use the `replace` method to replace newline characters with an empty string. This change should be made in the `handle` method of the `AuthenticateUserQueryHandler` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
