### PR TITLE
fix(security): configure CSRF token repository with domain customization

### DIFF
--- a/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/ApplicationSecurityProperties.kt
+++ b/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/ApplicationSecurityProperties.kt
@@ -17,7 +17,9 @@ import org.springframework.validation.annotation.Validated
  *
  * Properties:
  * - oauth2: The OAuth2 configuration properties. It is an instance of the inner [OAuth2] class.
+ * - cors: The CORS configuration properties. It is an instance of the inner [CorsProperties] class.
  * - contentSecurityPolicy: The Content Security Policy for the application.
+ * - domain: The domain for the application.
  *
  * Inner Class:
  * - [OAuth2]: Configuration properties for OAuth2 authentication.
@@ -48,7 +50,8 @@ import org.springframework.validation.annotation.Validated
 data class ApplicationSecurityProperties(
     val oauth2: OAuth2 = OAuth2(),
     val cors: CorsProperties = CorsProperties(),
-    val contentSecurityPolicy: String = CONTENT_SECURITY_POLICY
+    val contentSecurityPolicy: String = CONTENT_SECURITY_POLICY,
+    val domain: String = ""
 ) {
     data class OAuth2(
         val baseUrl: String = "",

--- a/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/SecurityConfiguration.kt
+++ b/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/SecurityConfiguration.kt
@@ -115,7 +115,13 @@ open class SecurityConfiguration(
             .csrf {
                     csrf ->
                 csrf
-                    .csrfTokenRepository(CookieServerCsrfTokenRepository.withHttpOnlyFalse())
+                    .csrfTokenRepository(
+                        CookieServerCsrfTokenRepository.withHttpOnlyFalse().apply {
+                            if (applicationSecurityProperties.domain.isNotEmpty()) {
+                                setCookieCustomizer { it.domain(applicationSecurityProperties.domain) }
+                            }
+                        },
+                    )
                     .csrfTokenRequestHandler(ServerCsrfTokenRequestAttributeHandler())
             }
             .cors {

--- a/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/SecurityConfiguration.kt
+++ b/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/SecurityConfiguration.kt
@@ -72,7 +72,7 @@ private const val POLICY =
 @Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
-open class SecurityConfiguration(
+class SecurityConfiguration(
     val applicationSecurityProperties: ApplicationSecurityProperties
 ) {
     @Value("\${spring.security.oauth2.client.provider.oidc.issuer-uri}")
@@ -86,7 +86,7 @@ open class SecurityConfiguration(
      * @return A [CorsConfigurationSource] object that is configured based on the applicationSecurityProperties.
      */
     @Bean
-    open fun corsConfigurationSource(): CorsConfigurationSource {
+    fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
         configuration.allowedOrigins = applicationSecurityProperties.cors.allowedOrigins
         configuration.allowedMethods = applicationSecurityProperties.cors.allowedMethods
@@ -106,7 +106,7 @@ open class SecurityConfiguration(
      * @return The configured SecurityWebFilterChain.
      */
     @Bean
-    open fun filterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
+    fun filterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
         // @formatter:off
         return http
             .securityMatcher(
@@ -236,7 +236,7 @@ open class SecurityConfiguration(
      * @return a [GrantedAuthoritiesMapper] that maps groups from the IdP to Spring Security Authorities.
      */
     @Bean
-    open fun userAuthoritiesMapper(): GrantedAuthoritiesMapper {
+    fun userAuthoritiesMapper(): GrantedAuthoritiesMapper {
         return GrantedAuthoritiesMapper { authorities ->
             val mappedAuthorities = HashSet<GrantedAuthority>()
 
@@ -259,7 +259,7 @@ open class SecurityConfiguration(
      */
     @Bean
     @Generated(reason = "Only called with a valid client registration repository")
-    open fun jwtDecoder(
+    fun jwtDecoder(
         clientRegistrationRepository: ReactiveClientRegistrationRepository,
         ssl: WebClientSsl
     ): ReactiveJwtDecoder {

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -87,6 +87,7 @@ application:
       exposed-headers: ${CORS_EXPOSED_HEADERS:Access-Control-Allow-Origin,Access-Control-Allow-Credentials}
       allow-credentials: ${CORS_ALLOW_CREDENTIALS:true}
       max-age: ${CORS_MAX_AGE:3600}
+    domain: ${HOSTNAME:localhost}
 
 management:
   endpoints:

--- a/apps/backend/src/test/kotlin/com/lyra/app/authentication/infrastructure/ApplicationSecurityPropertiesTest.kt
+++ b/apps/backend/src/test/kotlin/com/lyra/app/authentication/infrastructure/ApplicationSecurityPropertiesTest.kt
@@ -16,6 +16,7 @@ internal class ApplicationSecurityPropertiesTest {
         .withProperty("application.security.cors.allowedOrigins", "testAllowedOrigins")
         .withProperty("application.security.cors.allowedMethods", "testAllowedMethods")
         .withProperty("application.security.contentSecurityPolicy", "testContentSecurityPolicy")
+        .withProperty("application.security.domain", "testDomain")
     private val binder: Binder = Binder.get(environment)
 
     @Test
@@ -48,5 +49,15 @@ internal class ApplicationSecurityPropertiesTest {
         val properties = result.get()
 
         assertEquals("testContentSecurityPolicy", properties.contentSecurityPolicy)
+    }
+
+    @Test
+    fun `should bind domain property correctly`() {
+        val result: BindResult<ApplicationSecurityProperties> =
+            binder.bind("application.security", ApplicationSecurityProperties::class.java)
+
+        val properties = result.get()
+
+        assertEquals("testDomain", properties.domain)
     }
 }


### PR DESCRIPTION
Ensure the CSRF token repository is configured to set the domain for the CSRF cookie if the application domain is specified in the security properties.