### PR TITLE
test(security): add custom SpaCsrfTokenRequestHandler 

### DIFF
--- a/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/SecurityConfiguration.kt
+++ b/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/SecurityConfiguration.kt
@@ -1,6 +1,7 @@
 package com.lyra.app.authentication.infrastructure
 
 import com.lyra.app.authentication.domain.Role
+import com.lyra.app.authentication.infrastructure.csrf.SpaCsrfTokenRequestHandler
 import com.lyra.app.authentication.infrastructure.filter.CookieCsrfFilter
 import com.lyra.common.domain.Generated
 import java.time.Duration
@@ -37,7 +38,6 @@ import org.springframework.security.oauth2.server.resource.authentication.Reacti
 import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository
 import org.springframework.security.web.server.csrf.CsrfServerLogoutHandler
-import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestAttributeHandler
 import org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter
 import org.springframework.security.web.server.util.matcher.NegatedServerWebExchangeMatcher
 import org.springframework.security.web.server.util.matcher.OrServerWebExchangeMatcher
@@ -122,7 +122,7 @@ class SecurityConfiguration(
                             }
                         },
                     )
-                    .csrfTokenRequestHandler(ServerCsrfTokenRequestAttributeHandler())
+                    .csrfTokenRequestHandler(SpaCsrfTokenRequestHandler())
             }
             .cors {
                     cors ->

--- a/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/csrf/SpaCsrfTokenRequestHandler.kt
+++ b/apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/csrf/SpaCsrfTokenRequestHandler.kt
@@ -1,0 +1,41 @@
+package com.lyra.app.authentication.infrastructure.csrf
+
+import org.springframework.security.web.server.csrf.CsrfToken
+import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestAttributeHandler
+import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestHandler
+import org.springframework.security.web.server.csrf.XorServerCsrfTokenRequestAttributeHandler
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+
+class SpaCsrfTokenRequestHandler(
+    private val delegate: ServerCsrfTokenRequestHandler = XorServerCsrfTokenRequestAttributeHandler()
+) : ServerCsrfTokenRequestAttributeHandler() {
+
+    override fun handle(exchange: ServerWebExchange, csrfToken: Mono<CsrfToken>) {
+        /*
+         * Always use XorCsrfTokenRequestAttributeHandler to provide BREACH protection of
+         * the CsrfToken when it is rendered in the response body.
+         */
+        delegate.handle(exchange, csrfToken)
+    }
+
+    override fun resolveCsrfTokenValue(exchange: ServerWebExchange, csrfToken: CsrfToken): Mono<String> {
+        /*
+         * If the request contains a request header, use CsrfTokenRequestAttributeHandler
+         * to resolve the CsrfToken. This applies when a single-page application includes
+         * the header value automatically, which was obtained via a cookie containing the
+         * raw CsrfToken.
+         */
+        return if (exchange.request.headers.getFirst(csrfToken.headerName) != null) {
+            super.resolveCsrfTokenValue(exchange, csrfToken)
+        } else {
+            /*
+             * In all other cases (e.g. if the request contains a request parameter), use
+             * XorCsrfTokenRequestAttributeHandler to resolve the CsrfToken. This applies
+             * when a server-side rendered form includes the _csrf request parameter as a
+             * hidden input.
+             */
+            delegate.resolveCsrfTokenValue(exchange, csrfToken)
+        }
+    }
+}

--- a/apps/backend/src/test/kotlin/com/lyra/app/authentication/infrastructure/csrf/SpaCsrfTokenRequestHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/com/lyra/app/authentication/infrastructure/csrf/SpaCsrfTokenRequestHandlerTest.kt
@@ -1,0 +1,66 @@
+package com.lyra.app.authentication.infrastructure.csrf
+
+import com.lyra.UnitTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.web.server.csrf.CsrfToken
+import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestHandler
+import org.springframework.util.MultiValueMap
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+
+@UnitTest
+internal class SpaCsrfTokenRequestHandlerTest {
+
+    private lateinit var delegate: ServerCsrfTokenRequestHandler
+    private lateinit var handler: SpaCsrfTokenRequestHandler
+    private lateinit var exchange: ServerWebExchange
+    private lateinit var csrfToken: CsrfToken
+
+    @BeforeEach
+    fun setup() {
+        delegate = mockk()
+        handler = SpaCsrfTokenRequestHandler(delegate)
+        exchange = mockk()
+        csrfToken = mockk()
+
+        every { exchange.request.headers.getFirst(any()) } returns null
+        every { exchange.formData } returns Mono.empty<MultiValueMap<String, String>>()
+        every { delegate.handle(any(), any()) } returns Unit
+        every { delegate.resolveCsrfTokenValue(any(), any()) } returns Mono.just("token-value")
+    }
+
+    @Test
+    fun `should use delegate handle method`() {
+        val csrfTokenMono = Mono.just(csrfToken)
+
+        handler.handle(exchange, csrfTokenMono)
+
+        verify { delegate.handle(exchange, csrfTokenMono) }
+    }
+
+    @Test
+    fun `should resolve CsrfToken value from header`() {
+        every { csrfToken.headerName } returns "X-CSRF-TOKEN"
+        every { exchange.request.headers.getFirst("X-CSRF-TOKEN") } returns "header-token"
+
+        val result = handler.resolveCsrfTokenValue(exchange, csrfToken).block()
+
+        assertEquals("header-token", result)
+        verify { exchange.request.headers.getFirst("X-CSRF-TOKEN") }
+    }
+
+    @Test
+    fun `should delegate resolveCsrfTokenValue when header is not present`() {
+        every { csrfToken.headerName } returns "X-CSRF-TOKEN"
+
+        val result = handler.resolveCsrfTokenValue(exchange, csrfToken).block()
+
+        assertEquals("token-value", result)
+        verify { delegate.resolveCsrfTokenValue(exchange, csrfToken) }
+    }
+}

--- a/apps/backend/src/test/kotlin/com/lyra/app/authentication/infrastructure/http/UserAuthenticatorControllerIntegrationTest.kt
+++ b/apps/backend/src/test/kotlin/com/lyra/app/authentication/infrastructure/http/UserAuthenticatorControllerIntegrationTest.kt
@@ -176,7 +176,7 @@ internal class UserAuthenticatorControllerIntegrationTest : InfrastructureTestCo
 
     @Test
     fun `should throw exception when user is not verified`(): Unit = runBlocking {
-        val randomEmail = faker.internet().emailAddress()
+        val randomEmail = "yap@example.com"
         val randomPassword = faker.internet().password(8, 100, true, true, true) + "1Aa@"
         val user = createUser(email = randomEmail, password = randomPassword)
             .also {


### PR DESCRIPTION
This pull request introduces a new CSRF token request handler specifically designed for single-page applications (SPAs) and includes corresponding tests. Additionally, it contains a small change in the user authenticator controller integration test.

### CSRF Token Handling Enhancements:

* **Security Configuration Update:**
  - Replaced `ServerCsrfTokenRequestAttributeHandler` with `SpaCsrfTokenRequestHandler` in the `SecurityConfiguration` class. (`apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/SecurityConfiguration.kt`)
  - Removed unused import `ServerCsrfTokenRequestAttributeHandler` and added import for `SpaCsrfTokenRequestHandler`. (`apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/SecurityConfiguration.kt`) [[1]](diffhunk://#diff-5a444663aa76223e968d98c7509a3863f33ce6a9ed82abddc29a1713d33745b0R4) [[2]](diffhunk://#diff-5a444663aa76223e968d98c7509a3863f33ce6a9ed82abddc29a1713d33745b0L40)

* **New CSRF Token Request Handler:**
  - Created `SpaCsrfTokenRequestHandler` class to handle CSRF tokens in a way that supports both SPAs and server-side rendered forms. (`apps/backend/src/main/kotlin/com/lyra/app/authentication/infrastructure/csrf/SpaCsrfTokenRequestHandler.kt`)

* **Tests for New Handler:**
  - Added `SpaCsrfTokenRequestHandlerTest` to ensure the new handler works correctly, including handling and resolving CSRF tokens based on headers or request parameters. (`apps/backend/src/test/kotlin/com/lyra/app/authentication/infrastructure/csrf/SpaCsrfTokenRequestHandlerTest.kt`)

### Minor Change:

* **User Authenticator Controller Integration Test:**
  - Modified the test to use a fixed email address instead of generating a random one. (`apps/backend/src/test/kotlin/com/lyra/app/authentication/infrastructure/http/UserAuthenticatorControllerIntegrationTest.kt`)