### PR TITLE
fix: Delete codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-ignore:
-  - kotlin/com/lyra/app/aop


### PR DESCRIPTION
This pull request includes a small change to the `codecov.yml` file. The change removes the `ignore` section that previously excluded the `kotlin/com/lyra/app/aop` directory from code coverage.

* [`codecov.yml`](diffhunk://#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40dbL1-L2): Removed the `ignore` section that excluded the `kotlin/com/lyra/app/aop` directory from code coverage.